### PR TITLE
feat(stylelint-config-scss): remove dependency to `stylelint-config-sass-guidelines`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "rimraf": "^6.0.1",
         "semantic-release": "^24.2.0",
         "stylelint": "16.8.1",
-        "stylelint-config-sass-guidelines": "11.1.0",
         "stylelint-scss": "6.5.1",
         "tsx": "^4.19.1",
         "typescript": "^5.5.4",
@@ -11266,32 +11265,6 @@
         "postcss": "^8.4.31"
       }
     },
-    "node_modules/postcss-scss": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
-      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.29"
-      }
-    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -12754,23 +12727,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/stylelint-config-sass-guidelines": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-11.1.0.tgz",
-      "integrity": "sha512-mVE3UmN8MlshK4Gb3eYk6f8tw9DkQ9yjMF4W9krlmpaNZpSXOdh13AL0sU7l/9l4Pnpt4KMobNNIRI0tJl56Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-scss": "^4.0.9",
-        "stylelint-scss": "^6.2.1"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21",
-        "stylelint": "^16.1.0"
-      }
-    },
     "node_modules/stylelint-scss": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.5.1.tgz",
@@ -13805,7 +13761,6 @@
       "license": "MIT",
       "peerDependencies": {
         "stylelint": "^16.8.1",
-        "stylelint-config-sass-guidelines": "^11.1.0",
         "stylelint-scss": "^6.5.1"
       }
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "rimraf": "^6.0.1",
     "semantic-release": "^24.2.0",
     "stylelint": "16.8.1",
-    "stylelint-config-sass-guidelines": "11.1.0",
     "stylelint-scss": "6.5.1",
     "tsx": "^4.19.1",
     "typescript": "^5.5.4",

--- a/stylelint-config-scss/package.json
+++ b/stylelint-config-scss/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "peerDependencies": {
     "stylelint": "^16.8.1",
-    "stylelint-config-sass-guidelines": "^11.1.0",
     "stylelint-scss": "^6.5.1"
   }
 }

--- a/stylelint-config-scss/stylelintrc.yml
+++ b/stylelint-config-scss/stylelintrc.yml
@@ -1,6 +1,54 @@
-extends:
-  - stylelint-config-sass-guidelines
+plugins:
+  - stylelint-scss
 rules:
+  at-rule-disallowed-list:
+    - debug
+  at-rule-no-unknown: null
+  at-rule-no-vendor-prefix: true
+  block-no-empty: true
+  color-hex-length: short
+  color-no-invalid-hex: true
+  declaration-block-single-line-max-declarations: 1
+  declaration-property-value-disallowed-list:
+    border:
+      - none
+    border-top:
+      - none
+    border-right:
+      - none
+    border-bottom:
+      - none
+    border-left:
+      - none
+  function-url-quotes: always
+  length-zero-no-unit: true
+  media-feature-name-no-vendor-prefix: true
+  property-no-unknown: true
+  property-no-vendor-prefix: true
+  rule-empty-line-before:
+    - always-multi-line
+    - except:
+        - first-nested
+      ignore:
+        - after-comment
+  selector-class-pattern:
+    - '^[a-z0-9\-]+$'
+    - message: 'Selector should be written in lowercase with hyphens (selector-class-pattern)'
+  selector-max-id: 0
+  selector-no-vendor-prefix: true
+  selector-pseudo-element-colon-notation: double
+  shorthand-property-no-redundant-values: true
+  value-no-vendor-prefix: true
+  scss/at-function-pattern: '^[a-z]+([a-z0-9-]+[a-z0-9]+)?$'
+  scss/at-import-partial-extension-disallowed-list:
+    - scss
+  scss/at-rule-no-unknown: true
+  scss/dollar-variable-colon-space-before: never
+  scss/dollar-variable-pattern: '^[_]?[a-z]+([a-z0-9-]+[a-z0-9]+)?$'
+  scss/load-no-partial-leading-underscore: true
+  scss/no-global-function-names: true
+  scss/percent-placeholder-pattern: '^[a-z]+([a-z0-9-]+[a-z0-9]+)?$'
+  scss/selector-no-redundant-nesting-selector: true
   color-named: never
   color-no-hex: true
   declaration-no-important: true


### PR DESCRIPTION
`stylelint-config-sass-guidelines` added @ stylistic rules, which contradicts our strategy to use prettier. Therefore, this commit takes over the rules and removes the dependency to `stylelint-config-sass-guidelines`.