### PR TITLE
fix(plugin): exclude readonly member call expressions

### DIFF
--- a/eslint-plugin-defaultvalue/lib/rules/default-value.ts
+++ b/eslint-plugin-defaultvalue/lib/rules/default-value.ts
@@ -194,8 +194,16 @@ const extractCallExpression = (
         // This will never have a defaultValue.
         return undefined;
       }
+      // Should not be documented.
+      if (readonly) {
+        return undefined;
+      }
       return sourceCode.getText(callExpression);
     default:
+      // Should not be documented.
+      if (readonly) {
+        return undefined;
+      }
       return sourceCode.getText(callExpression);
   }
 };

--- a/eslint-plugin-defaultvalue/tests/rule-tester.test.ts
+++ b/eslint-plugin-defaultvalue/tests/rule-tester.test.ts
@@ -70,7 +70,12 @@ class Test {
   /** @internal */
   internal = 'internal';
 
+  private tempFunc: () => any = () => {};
+  private tempFuncObj = { sub: tempFunc } as const;
+
   readonly dontDefaultValueMe = 42;
+  readonly dontDefaultValueThisCall = this.temp();
+  readonly dontDefaultValueThisMemberCall = this.sub.temp();
   signalValue = input.required<number>();
   modelValue = model<string>();
 }


### PR DESCRIPTION
This covers a previously unhandled corner case to prevent readonly member call expressions from being documented.