### PR TITLE
refactor(plugin): remove unsupported config option

### DIFF
--- a/eslint-plugin-defaultvalue/README.md
+++ b/eslint-plugin-defaultvalue/README.md
@@ -33,16 +33,3 @@ export default [
   }
 ];
 ```
-
-### Removing not resolved and setter @defaultValue annotations
-
-To automatically remove not resolvable and setter @defaultValue annotations, use the following configuration:
-
-```js
-...,
-rules: {
-  ...,
-  'defaultvalue/tsdoc-defaultValue-annotation': ['error', 'removeAll', 1000]
-}
-...
-```

--- a/eslint-plugin-defaultvalue/lib/rules/default-value.ts
+++ b/eslint-plugin-defaultvalue/lib/rules/default-value.ts
@@ -256,12 +256,7 @@ export default createRule({
     docs: {
       description: 'enforce correct @defaultValue TSDoc annotation'
     },
-    schema: [
-      {
-        type: 'string',
-        enum: ['removeAll', 'default']
-      }
-    ] as const,
+    schema: [] as const,
     fixable: 'code',
     messages: {
       incorrectDefaultValueAnnotation: 'Incorrect @defaultValue TSDoc annotation: {{ message }}',


### PR DESCRIPTION
This removes a previously supported, now unsupported and unused config option from the schema and documentation.