### PR TITLE
chore(eslint-config): loosen eslint-plugin-import peer dep

### DIFF
--- a/eslint-config-angular/package.json
+++ b/eslint-config-angular/package.json
@@ -34,7 +34,7 @@
     "@eslint/js": "^9.9.1",
     "angular-eslint": "^18.1.0 || ^19.0.0",
     "eslint": "^9.9.1",
-    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@eslint/js": "^9.9.1",
     "eslint": "^9.9.1",
-    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"


### PR DESCRIPTION
Currently, the eslint-configs can not be installed via npm without workarounds because eslint 9 is not an allowed peer dependency of the recently fixed older version of eslint-plugin-import. We should at least allow newer versions until we find a better solution.