### PR TITLE
fix(eslint-config): remove formatting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ will get changed in the patch releases._
 
 ### ESLint
 
+Our ESLint configurations does not include any formatting rules.
+Please use a formatter like [Prettier](https://prettier.io/)
+or add a formatting ruleset for ESLint like [ESLint Stylistic](https://eslint.style/).
+
 #### TypeScript
 
 Include the ESLint preset in your root `eslint.config.mjs`:
@@ -86,7 +90,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export const tsConfig = typescriptEslint.config({
-  extends: [...angularTypescriptConfig, prettier],
+  extends: [...angularTypescriptConfig],
   files: ['**/*.ts'],
   languageOptions: {
     parserOptions: {
@@ -115,7 +119,7 @@ export const tsConfig = typescriptEslint.config({
 });
 
 export const templateConfig = typescriptEslint.config({
-  extends: [...angularTemplateConfig, prettier],
+  extends: [...angularTemplateConfig],
   files: ['**/*.html']
 });
 

--- a/eslint-config-angular/index.mjs
+++ b/eslint-config-angular/index.mjs
@@ -49,12 +49,6 @@ export const configBase = typescriptEslint.config({
     'space-before-blocks': ['off'],
 
     '@typescript-eslint/array-type': ['error'],
-    '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
-    '@typescript-eslint/comma-dangle': ['error'],
-    '@typescript-eslint/comma-spacing': ['error'],
-    '@typescript-eslint/func-call-spacing': ['error'],
-    '@typescript-eslint/indent': ['error', 2, { SwitchCase: 1 }],
-    '@typescript-eslint/keyword-spacing': ['error'],
     '@typescript-eslint/member-ordering': ['off'],
     '@typescript-eslint/naming-convention': ['off'],
     '@typescript-eslint/no-non-null-asserted-optional-chain': ['error'],
@@ -66,10 +60,6 @@ export const configBase = typescriptEslint.config({
       { vars: 'all', args: 'none', ignoreRestSiblings: false }
     ],
     '@typescript-eslint/no-var-requires': ['error'],
-    '@typescript-eslint/space-infix-ops': ['error'],
-    '@typescript-eslint/space-before-blocks': ['error'],
-    '@typescript-eslint/type-annotation-spacing': ['error'],
-    '@typescript-eslint/object-curly-spacing': ['error', 'always'],
     '@typescript-eslint/no-explicit-any': ['off'],
     '@typescript-eslint/no-empty-function': ['off'],
     '@typescript-eslint/no-inferrable-types': ['error', { ignoreParameters: true }],
@@ -93,7 +83,6 @@ export const configBase = typescriptEslint.config({
     'no-multi-spaces': ['error'],
     'no-multiple-empty-lines': ['error'],
     'prefer-arrow/prefer-arrow-functions': ['off'],
-    'quote-props': ['error', 'consistent'],
     'semi-spacing': ['error'],
     'space-in-parens': ['error'],
     'space-unary-ops': ['error'],
@@ -171,7 +160,6 @@ export const configRecommended = typescriptEslint.config({
       }
     ],
 
-    '@typescript-eslint/no-extra-semi': ['error'],
     '@typescript-eslint/no-for-in-array': ['error'],
     '@typescript-eslint/no-implied-eval': ['error'],
     '@typescript-eslint/no-loop-func': ['error'],

--- a/eslint-config-typescript/index.mjs
+++ b/eslint-config-typescript/index.mjs
@@ -39,12 +39,6 @@ export const configBase = typescriptEslint.config({
     'space-before-blocks': ['off'],
 
     '@typescript-eslint/array-type': ['error'],
-    '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
-    '@typescript-eslint/comma-dangle': ['error'],
-    '@typescript-eslint/comma-spacing': ['error'],
-    '@typescript-eslint/func-call-spacing': ['error'],
-    '@typescript-eslint/indent': ['error', 2, { SwitchCase: 1 }],
-    '@typescript-eslint/keyword-spacing': ['error'],
     '@typescript-eslint/member-ordering': ['off'],
     '@typescript-eslint/naming-convention': ['off'],
     '@typescript-eslint/no-non-null-asserted-optional-chain': ['error'],
@@ -56,10 +50,6 @@ export const configBase = typescriptEslint.config({
       { vars: 'all', args: 'none', ignoreRestSiblings: false }
     ],
     '@typescript-eslint/no-var-requires': ['error'],
-    '@typescript-eslint/space-infix-ops': ['error'],
-    '@typescript-eslint/space-before-blocks': ['error'],
-    '@typescript-eslint/type-annotation-spacing': ['error'],
-    '@typescript-eslint/object-curly-spacing': ['error', 'always'],
     '@typescript-eslint/no-explicit-any': ['off'],
     '@typescript-eslint/no-empty-function': ['off'],
     '@typescript-eslint/no-inferrable-types': ['error', { ignoreParameters: true }],
@@ -83,7 +73,6 @@ export const configBase = typescriptEslint.config({
     'no-multi-spaces': ['error'],
     'no-multiple-empty-lines': ['error'],
     'prefer-arrow/prefer-arrow-functions': ['off'],
-    'quote-props': ['error', 'consistent'],
     'semi-spacing': ['error'],
     'space-in-parens': ['error'],
     'space-unary-ops': ['error'],
@@ -154,7 +143,6 @@ export const configRecommended = typescriptEslint.config({
       }
     ],
 
-    '@typescript-eslint/no-extra-semi': ['error'],
     '@typescript-eslint/no-for-in-array': ['error'],
     '@typescript-eslint/no-implied-eval': ['error'],
     '@typescript-eslint/no-loop-func': ['error'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import typescriptEslint from 'typescript-eslint';
 import angularTypescriptConfig from '@siemens/eslint-config-angular';
-import prettier from 'eslint-config-prettier';
 import tsdocPlugin from 'eslint-plugin-tsdoc';
 import eslintPluginHeaders from 'eslint-plugin-headers';
 
@@ -32,7 +31,7 @@ export default [
   },
   ...typescriptEslint.config({
     name: 'typescript-eslint',
-    extends: [...angularTypescriptConfig, prettier],
+    extends: [...angularTypescriptConfig],
     files: ['**/*.ts'],
     languageOptions: {
       parserOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "angular-eslint": "18.1.0",
         "cpy-cli": "^5.0.0",
         "eslint": "9.9.1",
-        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-headers": "^1.1.2",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jsdoc": "50.2.2",
@@ -62,7 +61,7 @@
         "@eslint/js": "^9.9.1",
         "angular-eslint": "^18.1.0 || ^19.0.0",
         "eslint": "^9.9.1",
-        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "typescript-eslint": "^8.0.0"
@@ -75,7 +74,7 @@
       "peerDependencies": {
         "@eslint/js": "^9.9.1",
         "eslint": "^9.9.1",
-        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "typescript-eslint": "^8.0.0"
@@ -4491,19 +4490,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "angular-eslint": "18.1.0",
     "cpy-cli": "^5.0.0",
     "eslint": "9.9.1",
-    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-headers": "^1.1.2",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jsdoc": "50.2.2",


### PR DESCRIPTION
BREAKING CHANGE: `eslint-config-typescript` and `eslint-config-angular` no longer ship any formatting rules, please use prettier or set up formatting rules yourself

Removes the non-functional formatting rules