### PR TITLE
fix(stylelint-config-scss): fix add missing parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-tsdoc": "^0.3.0",
         "husky": "^9.1.5",
+        "postcss-scss": "^4.0.9",
         "prettier": "^3.3.3",
         "rimraf": "^6.0.1",
         "semantic-release": "^24.2.0",
@@ -61,7 +62,7 @@
         "@eslint/js": "^9.9.1",
         "angular-eslint": "^18.1.0 || ^19.0.0",
         "eslint": "^9.9.1",
-        "eslint-plugin-import": "2.26.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "typescript-eslint": "^8.0.0"
@@ -74,7 +75,7 @@
       "peerDependencies": {
         "@eslint/js": "^9.9.1",
         "eslint": "^9.9.1",
-        "eslint-plugin-import": "2.26.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "typescript-eslint": "^8.0.0"
@@ -11197,6 +11198,32 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -13692,6 +13719,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "peerDependencies": {
+        "postcss-scss": "^4.0.0",
         "stylelint": "^16.8.1",
         "stylelint-scss": "^6.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-tsdoc": "^0.3.0",
     "husky": "^9.1.5",
+    "postcss-scss": "^4.0.9",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "semantic-release": "^24.2.0",

--- a/stylelint-config-scss/package.json
+++ b/stylelint-config-scss/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "postcss-scss": "^4.0.0",
     "stylelint": "^16.8.1",
     "stylelint-scss": "^6.5.1"
   }

--- a/stylelint-config-scss/stylelintrc.yml
+++ b/stylelint-config-scss/stylelintrc.yml
@@ -1,5 +1,6 @@
 plugins:
   - stylelint-scss
+customSyntax: postcss-scss
 rules:
   at-rule-disallowed-list:
     - debug


### PR DESCRIPTION
The parser option got lost when merging the configs into element.

It is actually needed and it seems like that `postcss-scss` is the only parser available. It was also used before.