### PR TITLE
refactor: prettier-config from json to js

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Include the commitlint preset in your `package.json`:
 Include the shared Prettier config in your `package.json`:
 
 ```json
-"prettier": "@siemens/prettier-config/.prettierrc.json",
+"prettier": "@siemens/prettier-config",
 ```
 
 ### ESLint Plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -10191,7 +10191,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "license": "MIT",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12193,6 +12193,9 @@
       "name": "@siemens/prettier-config",
       "version": "0.0.0-development",
       "license": "MIT",
+      "devDependencies": {
+        "prettier": "3.4.2"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "./commitlint-config/.commitlintrc.js"
     ]
   },
-  "prettier": "./prettier-config/.prettierrc.json",
+  "prettier": "./prettier-config/index.js",
   "workspaces": [
     "commitlint-config",
     "eslint-config-angular",

--- a/prettier-config/index.js
+++ b/prettier-config/index.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright Siemens 2024.
+ * SPDX-License-Identifier: MIT
+ *
+ /
+
+ /**
+ * @type { import("prettier").Config }
+ */
+const config = {
+  printWidth: 100,
+  trailingComma: 'none',
+  arrowParens: 'avoid',
+  htmlWhitespaceSensitivity: 'strict',
+  quoteProps: 'preserve',
+  singleQuote: true,
+  overrides: [
+    {
+      files: '*.html',
+      options: {
+        parser: 'angular'
+      }
+    },
+    {
+      files: 'index.html',
+      options: {
+        parser: 'html'
+      }
+    },
+    {
+      files: '*.json5',
+      options: {
+        singleQuote: false
+      }
+    }
+  ]
+};
+
+export default config;

--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -2,13 +2,13 @@
   "name": "@siemens/prettier-config",
   "version": "0.0.0-development",
   "description": "Configuration for Prettier.",
-  "files": [
-    "*.json",
-    "*.md"
-  ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/siemens/lint.git"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./prettierrc.json": "./.prettierrc.json"
   },
   "author": {
     "name": "Siemens",
@@ -24,7 +24,11 @@
     "access": "public"
   },
   "license": "MIT",
+  "type": "module",
   "peerDependencies": {
     "prettier": "^3.0.0"
+  },
+  "devDependencies": {
+    "prettier": "3.4.2"
   }
 }


### PR DESCRIPTION
This was done so that the base config is extensible which will allow other projects to install any prettier plugins that might be relevant for their project, e.g. prettier-plugin-tailwind.