### PR TITLE
fix(prettier-config): keep JSON config export as before

### DIFF
--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -8,7 +8,7 @@
   },
   "exports": {
     ".": "./index.js",
-    "./prettierrc.json": "./.prettierrc.json"
+    "./.prettierrc.json": "./.prettierrc.json"
   },
   "author": {
     "name": "Siemens",


### PR DESCRIPTION
This was unintentionally broken before. This restores the previous behaior.