### PR TITLE
feat(eslint-config-typescript): relax rule '@typescript-eslint/prefer-nullish-coalescing'

### DIFF
--- a/eslint-config-typescript/index.mjs
+++ b/eslint-config-typescript/index.mjs
@@ -58,6 +58,7 @@ export const configBase = typescriptEslint.config({
     '@typescript-eslint/no-unused-expressions': ['error'],
     '@typescript-eslint/prefer-for-of': ['error'],
     '@typescript-eslint/prefer-function-type': ['error'],
+    '@typescript-eslint/prefer-nullish-coalescing': ['error', { ignorePrimitives: true }],
     '@typescript-eslint/unified-signatures': ['error'],
 
     'no-duplicate-imports': ['error'],


### PR DESCRIPTION
Relax the rule by enabling `ignorePrimitives`. Reason is that the rule suggest changes that break working code. E.g. `a || b` vs `a ?? b` is something completely different when `a` is a string or a number, yet the rule suggests the change.