### PR TITLE
refactor(eslint): drop use of deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Include the ESLint preset in your root `eslint.config.mjs`:
 ```js
 import path from 'path';
 import { fileURLToPath } from 'url';
-import typescriptEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import typescriptConfig from '@siemens/eslint-config-typescript';
 
 // mimic CommonJS variables
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default typescriptEslint.config({
+export default defineConfig({
   extends: [...typescriptConfig],
   files: ['**/*.ts'],
   languageOptions: {
@@ -80,7 +80,7 @@ Include the ESLint preset in your root `eslint.config.mjs`:
 ```js
 import path from 'path';
 import { fileURLToPath } from 'url';
-import typescriptEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import angularTypescriptConfig from '@siemens/eslint-config-angular';
 import angularTemplateConfig from '@siemens/eslint-config-angular/template';
 
@@ -88,7 +88,7 @@ import angularTemplateConfig from '@siemens/eslint-config-angular/template';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const tsConfig = typescriptEslint.config({
+const tsConfig = defineConfig({
   extends: [...angularTypescriptConfig],
   files: ['**/*.ts'],
   languageOptions: {
@@ -117,22 +117,22 @@ const tsConfig = typescriptEslint.config({
   }
 });
 
-const templateConfig = typescriptEslint.config({
+const templateConfig = defineConfig({
   extends: [...angularTemplateConfig],
   files: ['**/*.html']
 });
 
-export default typescriptEslint.config(...tsConfig, ...templateConfig);
+export default defineConfig(...tsConfig, ...templateConfig);
 ```
 
 For libraries and other things in the `projects` directory,
 create an additional `eslint.config.mjs` for each project that looks like this:
 
 ```js
-import typescriptEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import { tsConfig, templateConfig } from '../../eslint.config.mjs';
 
-export default typescriptEslint.config(
+export default defineConfig(
   {
     extends: [...tsConfig],
     files: ['**/*.ts'],

--- a/eslint-config-angular/index.mjs
+++ b/eslint-config-angular/index.mjs
@@ -7,10 +7,11 @@ import typescriptEslint from 'typescript-eslint';
 import angularEslint from 'angular-eslint';
 import perfectionist from 'eslint-plugin-perfectionist';
 import preferArrowPlugin from 'eslint-plugin-prefer-arrow';
+import { defineConfig } from 'eslint/config';
 
 // Keep in sync with eslint-config-typescript (except Angular stuff).
 
-export const configBase = typescriptEslint.config({
+export const configBase = defineConfig({
   extends: [
     eslintJs.configs.recommended,
     ...typescriptEslint.configs.recommended,
@@ -78,7 +79,7 @@ export const configBase = typescriptEslint.config({
   }
 });
 
-export const configRecommended = typescriptEslint.config({
+export const configRecommended = defineConfig({
   extends: [...angularEslint.configs.tsAll, ...configBase],
   plugins: {
     'prefer-arrow': preferArrowPlugin

--- a/eslint-config-angular/package.json
+++ b/eslint-config-angular/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@eslint/js": "^9.9.1 || ^10.0.0",
     "angular-eslint": "^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
-    "eslint": "^9.9.1 || ^10.0.0",
+    "eslint": "^9.22.0 || ^10.0.0",
     "eslint-plugin-perfectionist": "^4.15.0 || ^5.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"

--- a/eslint-config-angular/template.mjs
+++ b/eslint-config-angular/template.mjs
@@ -2,12 +2,12 @@
  * Copyright Siemens 2026.
  * SPDX-License-Identifier: MIT
  */
-import typescriptEslint from 'typescript-eslint';
 import angularEslint from 'angular-eslint';
+import { defineConfig } from 'eslint/config';
 
-export const configBase = typescriptEslint.config(...angularEslint.configs.templateRecommended);
+export const configBase = defineConfig(...angularEslint.configs.templateRecommended);
 
-export const configRecommended = typescriptEslint.config({
+export const configRecommended = defineConfig({
   extends: [...angularEslint.configs.templateAll, ...configBase],
   rules: {
     '@angular-eslint/template/click-events-have-key-events': ['off'],

--- a/eslint-config-typescript/index.mjs
+++ b/eslint-config-typescript/index.mjs
@@ -6,10 +6,11 @@ import eslintJs from '@eslint/js';
 import typescriptEslint from 'typescript-eslint';
 import perfectionist from 'eslint-plugin-perfectionist';
 import preferArrowPlugin from 'eslint-plugin-prefer-arrow';
+import { defineConfig } from 'eslint/config';
 
 // Keep in sync with eslint-config-angular (except Angular stuff).
 
-export const configBase = typescriptEslint.config({
+export const configBase = defineConfig({
   extends: [eslintJs.configs.recommended, ...typescriptEslint.configs.recommended],
   plugins: {
     perfectionist
@@ -68,7 +69,7 @@ export const configBase = typescriptEslint.config({
   }
 });
 
-export const configRecommended = typescriptEslint.config({
+export const configRecommended = defineConfig({
   extends: [...configBase],
   plugins: {
     'prefer-arrow': preferArrowPlugin

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@eslint/js": "^9.9.1 || ^10.0.0",
-    "eslint": "^9.9.1 || ^10.0.0",
+    "eslint": "^9.22.0 || ^10.0.0",
     "eslint-plugin-perfectionist": "^4.15.0 || ^5.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@
 import eslintJs from '@eslint/js';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import typescriptEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import angularTypescriptConfig from '@siemens/eslint-config-angular';
 import tsdocPlugin from 'eslint-plugin-tsdoc';
 import eslintPluginHeaders from 'eslint-plugin-headers';
@@ -29,7 +29,7 @@ export default [
       ]
     }
   },
-  ...typescriptEslint.config({
+  ...defineConfig({
     name: 'typescript-eslint',
     extends: [...angularTypescriptConfig],
     files: ['**/*.ts'],


### PR DESCRIPTION
replaces deprecated `typescriptEslint.config` method of `typescript-eslint` with `defineConfig` of `eslint/config`