### PR TITLE
build: use tokenless release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
-      - release/*
-      - next
   pull_request:
 jobs:
   build-and-test:
@@ -25,34 +20,3 @@ jobs:
       - run: npm run lint:commit
       - run: npm run lint
       - run: npm run plugin:test
-
-  release:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' ||  startsWith(github.ref, 'refs/heads/release/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
-    needs: build-and-test
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0 # semantic-release needs this
-          token: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }} # Otherwise, branch protection rules are not bypassed.
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-      - name: Semantic Release
-        run: npx semantic-release
-        env:
-          GIT_AUTHOR_NAME: 'Siemens Element Bot'
-          GIT_AUTHOR_EMAIL: 'simpl.si@siemens.com'
-          GIT_COMMITTER_NAME: 'Siemens Element Bot'
-          GIT_COMMITTER_EMAIL: 'simpl.si@siemens.com'
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+      - next
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # semantic-release needs this
+          token: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }} # Otherwise, branch protection rules are not bypassed.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Semantic Release
+        run: npx semantic-release
+        env:
+          GIT_AUTHOR_NAME: 'Siemens Element Bot'
+          GIT_AUTHOR_EMAIL: 'simpl.si@siemens.com'
+          GIT_COMMITTER_NAME: 'Siemens Element Bot'
+          GIT_COMMITTER_EMAIL: 'simpl.si@siemens.com'
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
See: https://docs.npmjs.com/trusted-publishers#supported-cicd-providers