### PR TITLE
build(.releaserc.js): disable success comments for releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,6 +50,11 @@
         "pkgRoot": "dist/stylelint-config-scss"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Back-merge of https://github.com/siemens/element/pull/1176.