### PR TITLE
feat(eslint-config-angular): support eslint-plugin-perfectionist@5

### DIFF
--- a/eslint-config-angular/index.mjs
+++ b/eslint-config-angular/index.mjs
@@ -96,7 +96,7 @@ export const configRecommended = typescriptEslint.config({
       {
         type: 'alphabetical',
         order: 'asc',
-        newlinesBetween: 'always',
+        newlinesBetween: 1,
         groups: [
           ['builtin', 'external'],
           ['parent', 'sibling', 'index']

--- a/eslint-config-angular/package.json
+++ b/eslint-config-angular/package.json
@@ -34,7 +34,7 @@
     "@eslint/js": "^9.9.1",
     "angular-eslint": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "eslint": "^9.9.1",
-    "eslint-plugin-perfectionist": "^4.6.0",
+    "eslint-plugin-perfectionist": "^4.15.0 || ^5.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"
   }

--- a/eslint-config-typescript/index.mjs
+++ b/eslint-config-typescript/index.mjs
@@ -86,7 +86,7 @@ export const configRecommended = typescriptEslint.config({
       {
         type: 'alphabetical',
         order: 'asc',
-        newlinesBetween: 'always',
+        newlinesBetween: 1,
         groups: [
           ['builtin', 'external'],
           ['parent', 'sibling', 'index']

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@eslint/js": "^9.9.1",
     "eslint": "^9.9.1",
-    "eslint-plugin-perfectionist": "^4.6.0",
+    "eslint-plugin-perfectionist": "^4.15.0 || ^5.0.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "typescript-eslint": "^8.0.0"
   }


### PR DESCRIPTION
Since version `4.15.0` `newlinesBetween` supports a number. See https://github.com/azat-io/eslint-plugin-perfectionist/releases/tag/v4.15.0

Since version `5.0.0` the keyword `always` is no longer supported. See https://github.com/azat-io/eslint-plugin-perfectionist/releases/tag/v5.0.0

So we need a min version of 4.15.0.

BREAKING CHANGE: `eslint-plugin-perfectionist` version range `^4.15.0 || ^5.0.0` is now required.


This is tested in element.