### PR TITLE
build(renovate): extending major peer dependencies are not breaking

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -58,8 +58,7 @@
       "matchDepTypes": ["peerDependencies"],
       "matchUpdateTypes": ["major"],
       "groupName": "major renovate version",
-      "semanticCommitType": "feat",
-      "commitBody": "BREAKING CHANGE: Major renovate update"
+      "semanticCommitType": "feat"
     },
     {
       "description": "Trigger minor release from minor renovate release",


### PR DESCRIPTION
Currently, when renovate allows an additional new major version in a peer dependency range, the commit get a breaking change note. This is pointless, as this is not breaking.

For instance changing `"stylelint": "^16.8.1"` to `"stylelint": "^16.8.1 || ^17.0.0"` is not breaking.