### PR TITLE
build(renovate): scope peer dep updates by package family

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -51,25 +51,34 @@
       enabled: true
     },
     {
-      description: "Trigger major release from major renovate release",
+      description: "Major peer dep bumps trigger a feat release",
       matchDepTypes: ["peerDependencies"],
       matchUpdateTypes: ["major"],
-      groupName: "major renovate version",
       semanticCommitType: "feat"
     },
     {
-      description: "Trigger minor release from minor renovate release",
-      matchDepTypes: ["peerDependencies"],
-      matchUpdateTypes: ["minor"],
-      groupName: "minor renovate version",
-      semanticCommitType: "feat"
+      description: "Shared eslint peers + angular-eslint -> eslint scope",
+      matchPackageNames: [
+        "eslint",
+        "@eslint/js",
+        "typescript-eslint",
+        "eslint-plugin-perfectionist",
+        "eslint-plugin-prefer-arrow",
+        "angular-eslint"
+      ],
+      semanticCommitScope: "eslint"
     },
     {
-      description: "Trigger patch release from patch renovate release",
-      matchDepTypes: ["peerDependencies"],
-      matchUpdateTypes: ["patch"],
-      groupName: "patch renovate version",
-      semanticCommitType: "fix"
+      matchPackageNames: ["@commitlint/cli", "@commitlint/config-conventional"],
+      semanticCommitScope: "commitlint"
+    },
+    {
+      matchPackageNames: ["prettier"],
+      semanticCommitScope: "prettier"
+    },
+    {
+      matchPackageNames: ["postcss-scss", "stylelint", "stylelint-scss"],
+      semanticCommitScope: "stylelint"
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,43 +14,6 @@
   timezone: "Etc/UTC",
   packageRules: [
     {
-      description: [
-        "Prevent Angular related major and minor updates. Those should be manually done"
-      ],
-      matchPackageNames: [
-        "@angular/**",
-        "@angular-devkit/**",
-        "@angular-eslint/**",
-        "@angular-architects/**",
-        "@angular-builders/**",
-        "ng-packagr",
-        "rxjs",
-        "typescript",
-        "zone.js",
-        "tslib"
-      ],
-      matchUpdateTypes: ["major", "minor"],
-      enabled: false
-    },
-    {
-      groupName: "Angular dependencies",
-      description: ["Update Angular packages"],
-      matchPackageNames: [
-        "@angular/**",
-        "@angular-devkit/**",
-        "@angular-eslint/**",
-        "@angular-architects/**",
-        "@angular-builders/**",
-        "ng-packagr",
-        "rxjs",
-        "typescript",
-        "zone.js",
-        "tslib"
-      ],
-      matchUpdateTypes: ["patch"],
-      enabled: true
-    },
-    {
       description: "Major peer dep bumps trigger a feat release",
       matchDepTypes: ["peerDependencies"],
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
Renovate merges all matching `packageRules` per dependency — they are additive, not exclusive. Later rules only override earlier ones on conflicting fields. The rules here set different fields:

- Major-peer rule sets `semanticCommitType`
- Scope rules set `semanticCommitScope`

So for a major `eslint` peer bump, both apply: `feat(eslint): update eslint to v10`.

For a non-major `eslint` update the major rule does not match and falls back to `chore` from `:semanticCommitTypeAll(chore)`; the scope rule still matches, yielding `chore(eslint): ...`.

One caveat: `group:allNonMajor` bundles all non-major updates into a single PR with its own group commit message (`chore(deps): update all non-major dependencies`). Inside a grouped PR the per-package `semanticCommitScope` does not surface — the group topic wins. So the scope rules effectively only show up on:

- Major peer PRs (individual, get `feat(<scope>)`)
- Major non-peer PRs (individual, get `chore(<scope>)`)

Non-major updates stay lumped together regardless.