### PR TITLE
fix: use public repository metadata

### DIFF
--- a/commitlint-config/package.json
+++ b/commitlint-config/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",

--- a/eslint-config-angular/package.json
+++ b/eslint-config-angular/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -9,7 +9,7 @@
   "main": "./index.mjs",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",

--- a/eslint-plugin-defaultvalue/package.json
+++ b/eslint-plugin-defaultvalue/package.json
@@ -6,7 +6,7 @@
   "description": "Automatically enrich TSDoc comments with default values or check if they are all correct.",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",

--- a/prettier-config/package.json
+++ b/prettier-config/package.json
@@ -4,7 +4,7 @@
   "description": "Configuration for Prettier.",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "exports": {
     ".": "./index.js",

--- a/stylelint-config-scss/package.json
+++ b/stylelint-config-scss/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/siemens/lint.git"
+    "url": "git+https://github.com/siemens/lint.git"
   },
   "author": {
     "name": "Siemens",


### PR DESCRIPTION
## Summary
- update repository metadata in the root manifest and all package manifests from SSH-style GitHub URLs to the public `git+https://github.com/siemens/lint.git` URL
- keep runtime code, dependencies, package contents, homepage, bugs metadata, and licenses unchanged

## Why this is needed
The packages are public, but their npm repository metadata used SSH-style GitHub URLs such as `git+ssh://git@github.com/siemens/lint.git` or `git@github.com:siemens/lint.git`. Public `git+https` metadata is easier for npm clients, registry consumers, scanners, and read-only tooling to resolve without requiring GitHub SSH credentials. This is a metadata-only cleanup and does not affect package behavior.

## Packages updated
- root `package.json`
- `commitlint-config/package.json`
- `eslint-config-angular/package.json`
- `eslint-config-typescript/package.json`
- `eslint-plugin-defaultvalue/package.json`
- `prettier-config/package.json`
- `stylelint-config-scss/package.json`

## Validation
- `node -e "const fs=require('fs'); const paths=['package.json','commitlint-config/package.json','eslint-config-angular/package.json','eslint-config-typescript/package.json','eslint-plugin-defaultvalue/package.json','prettier-config/package.json','stylelint-config-scss/package.json']; for (const path of paths) { const p=JSON.parse(fs.readFileSync(path,'utf8')); if (p.repository?.url !== 'git+https://github.com/siemens/lint.git') throw new Error(path + ' repository metadata not fixed'); } console.log('all package metadata ok')"`
- `git diff --check`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./commitlint-config`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./eslint-config-angular`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./eslint-config-typescript`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./eslint-plugin-defaultvalue`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./prettier-config`
- `npm --cache "$env:TEMP\codex-npm-cache" pack --dry-run --ignore-scripts --json ./stylelint-config-scss`